### PR TITLE
Darken highlighted code for easier reading

### DIFF
--- a/layouts/partials/paige/dark.css
+++ b/layouts/partials/paige/dark.css
@@ -6,7 +6,7 @@
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { background-color: #4f4f4d }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
 /* LineNumbers */ .chroma .ln { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
 /* Line */ .chroma .line { display: flex; }


### PR DESCRIPTION
Highlighted code block is difficult to read because of the bright yellow background. 

This PR intends to change the highlight color to a darker yellow, which makes reading a lot easier.
