### PR TITLE
Fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ please share it by [posting a link](https://github.com/willfaught/paige/discussi
 
 ## Setup
 
-1. [Install Hugo](https://gohugo.io/installation/) (the extended version, and at least 0.111.3).
+1. [Install Hugo](https://gohugo.io/installation/) (the extended version, and at least 0.123.0).
 
     For Homebrew on Mac:
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,7 +2,7 @@
 suffixes = ["xml"]
 
 [module.hugoversion]
-min = "0.111.3"
+min = "0.123.0"
 extended = true
 
 # Default mounts

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -10,7 +10,7 @@
 {{ $rights := site.Copyright | markdownify }}
 {{ $subpages := slice }}
 {{ $subtitle := $page.Description | markdownify }}
-{{ $updated := site.LastChange.Format $format }}
+{{ $updated := site.Lastmod.Format $format }}
 
 {{ range $page.RegularPagesRecursive.ByPublishDate.Reverse }}
     {{ if not (.Param "paige.feed.hide_page") }}


### PR DESCRIPTION
When running the example with latest hugo version 0.127.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.LastChange was deprecated in Hugo v0.123.0
and will be removed in a future release. Use .Site.Lastmod instead.
```

This PR fixes that warning.
This PR completes the German translation on the way.