### PR TITLE
Complete German translation

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,5 +1,5 @@
 paige_breadcrumbs:
-  other: Semmelbrösel
+  other: Brotkrumen
 
 paige_collections:
   other: Sammlungen
@@ -10,15 +10,39 @@ paige_figure:
 paige_aria_section_link:
   other: Verweise auf diesen Abschnitt
 
+paige_edit_history:
+  other: Historie bearbeiten
+
+paige_edit_this_page:
+  other: Diese Seite bearbeiten
+
+paige_first:
+  other: Erste
+
+paige_last:
+  other: Letzte
+
 paige_minutes:
   one: Minute
   other: Minuten
 
+paige_next:
+  other: Nächste
+
 paige_noscript:
   other: JavaScript wird benötigt.
 
+paige_page_list_navigation:
+  other: Navigation Seitenleiste
+
 paige_pages:
   other: Seiten
+
+paige_previous:
+  other: Vorherige
+
+paige_recent_content:
+  other: Neueste Inhalte
 
 paige_search_button:
   other: Suche


### PR DESCRIPTION
This PR completes and improves the German translation.

The term `Semmelbrösel` is wrong and is misleading. Since you prefer German phrases, I changed it to `Brotkrumen`. That's in line with the [terminology](https://de.wikipedia.org/wiki/Brotkr%C3%BCmelnavigation).