### PR TITLE
Fixes #122

### DIFF
--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -2,3 +2,4 @@
 {{- $target := partial "paige/func-target.html" (dict "page" .Page "url" .Destination) -}}
 
 <a {{ with .Destination }} href="{{ . }}" {{ end }} {{ if $external }} rel="external" {{ end }} {{ with $target }} target="{{ . }}" {{ end }} {{ with .Title }} title="{{ . }}" {{ end }}>{{ .Text }}</a>
+{{- /* This comment removes trailing newlines. */ -}}


### PR DESCRIPTION
Removes the trailing whitespace using the {{‑ ‑}} delimiter notation.